### PR TITLE
Ci-en 투고 기사 정보 가져오기 구현

### DIFF
--- a/src/main/collectors/cien-collector.ts
+++ b/src/main/collectors/cien-collector.ts
@@ -1,0 +1,65 @@
+import dayjs from "dayjs";
+import { parse } from "node-html-parser";
+import { Collector } from "./registry.js";
+
+export const CienCollector: Collector = {
+  name: "Ci-en",
+  getId: async (path) => {
+    const id = /(?:CE|CIEN|CI-EN)(\d+-\d+)/i.exec(path)?.[1];
+    return id;
+  },
+  fetchInfo: async ({ id }) => {
+    const [creatorId, articleId] = id
+      .split("-")
+      .map((s) => s.replace(/^0+/, ""));
+    const html = await fetch(
+      `https://ci-en.net/creator/${creatorId}/article/${articleId}`,
+    ).then((res) => res.text());
+
+    const body = parse(html, {
+      blockTextElements: {
+        script: false,
+        noscript: false,
+        style: false,
+        pre: false,
+      },
+    });
+
+    // 게시물 찾기
+    const article = body.getElementById(`article-${articleId}`);
+
+    // 섬네일 정보 수집
+    const image = article?.querySelector(".file-player-image-wrapper")
+      ?.children[0].children[0];
+    const thumbnail = image?.getAttribute("src");
+
+    // 제목 수집
+    const collectorTitle =
+      article?.querySelector(".article-title")?.textContent;
+
+    // 발매일 수집
+    const publishDateString =
+      article?.parentNode.querySelector(".e-date")?.innerText;
+    const date = dayjs(publishDateString);
+    const publishDate = date.isValid() ? date.toDate() : new Date();
+
+    // 제작사 수집
+    const makerName =
+      article?.parentNode.querySelector("e-userName")?.innerText;
+
+    // 카테고리 X
+    const category = "";
+
+    // 태그 X
+    const tags = [];
+
+    return {
+      collectorTitle,
+      thumbnail,
+      publishDate,
+      makerName,
+      category,
+      tags,
+    };
+  },
+};

--- a/src/main/collectors/cien-collector.ts
+++ b/src/main/collectors/cien-collector.ts
@@ -39,13 +39,16 @@ export const CienCollector: Collector = {
 
     // 발매일 수집
     const publishDateString =
-      article?.parentNode.querySelector(".e-date")?.innerText;
+      article?.parentNode.parentNode.querySelector(".e-date")?.innerText;
+
+    console.log(publishDateString);
+
     const date = dayjs(publishDateString);
     const publishDate = date.isValid() ? date.toDate() : new Date();
 
     // 제작사 수집
     const makerName =
-      article?.parentNode.querySelector("e-userName")?.innerText;
+      article?.parentNode.parentNode.querySelector(".e-userName")?.innerText;
 
     // 카테고리 X
     const category = "";

--- a/src/main/collectors/cien-collector.ts
+++ b/src/main/collectors/cien-collector.ts
@@ -40,9 +40,6 @@ export const CienCollector: Collector = {
     // 발매일 수집
     const publishDateString =
       article?.parentNode.parentNode.querySelector(".e-date")?.innerText;
-
-    console.log(publishDateString);
-
     const date = dayjs(publishDateString);
     const publishDate = date.isValid() ? date.toDate() : new Date();
 

--- a/src/main/collectors/cien-collector.ts
+++ b/src/main/collectors/cien-collector.ts
@@ -5,7 +5,7 @@ import { Collector } from "./registry.js";
 export const CienCollector: Collector = {
   name: "Ci-en",
   getId: async (path) => {
-    const id = /(?:CE|CIEN|CI-EN)(\d+-\d+|creator\d+article\d+)/i
+    const id = /(?:CE|CIEN|CI-EN)(\d+-\d+|(creator)?\d+article\d+)/i
       .exec(path)?.[1]
       ?.replace("creator", "")
       .replace("article", "-");

--- a/src/main/collectors/cien-collector.ts
+++ b/src/main/collectors/cien-collector.ts
@@ -5,7 +5,10 @@ import { Collector } from "./registry.js";
 export const CienCollector: Collector = {
   name: "Ci-en",
   getId: async (path) => {
-    const id = /(?:CE|CIEN|CI-EN)(\d+-\d+)/i.exec(path)?.[1];
+    const id = /(?:CE|CIEN|CI-EN)(\d+-\d+|creator\d+article\d+)/i
+      .exec(path)?.[1]
+      ?.replace("creator", "")
+      .replace("article", "-");
     return id;
   },
   fetchInfo: async ({ id }) => {

--- a/src/main/collectors/registry.ts
+++ b/src/main/collectors/registry.ts
@@ -1,5 +1,6 @@
 import { Page } from "puppeteer-core";
 import { db } from "../db/db-manager.js";
+import { CienCollector } from "./cien-collector.js";
 import { DLSiteCollector } from "./dlsite-collector.js";
 import { GetchuCollector } from "./getchu-collector.js";
 import { SteamCollector } from "./steam-collector.js";
@@ -31,6 +32,7 @@ export const collectors: Collector[] = [
   DLSiteCollector,
   SteamCollector,
   GetchuCollector,
+  CienCollector,
   // GoogleCollector,
 ];
 

--- a/src/main/handlers/thumbnail.ts
+++ b/src/main/handlers/thumbnail.ts
@@ -132,6 +132,25 @@ ipcMain.on(
           });
           downloaded = true;
         }
+
+        // Ci-en 다운로드
+        if (collector.name === "Ci-en" && info?.thumbnail) {
+          const thumbnailUrl = new URL(info.thumbnail);
+          thumbnailUrl.search = "";
+
+          const thumbnailExt = extname(thumbnailUrl.toString());
+          const thumbnailName = changeThumbnailFolder
+            ? join(savePath, fileName) + thumbnailExt
+            : await getThumbnailName({
+                filePath,
+                thumbnailExt,
+              });
+          await saveFromUrl({
+            fileName: thumbnailName,
+            imgUrl: info.thumbnail,
+          });
+          downloaded = true;
+        }
       }
 
       // 구글 검색 다운로드


### PR DESCRIPTION
"CE"/"CIEN"/"CI-EN" + 창작자 ID + "-" + 게시물 ID 또는
"CE"/"CIEN"/"CI-EN" (+ "creator") + 창작자 ID + "article" + 게시물 ID의
형식으로 가져올 수 있으며, 접두사는 대소문자를 구분하지 않습니다. 정렬을 위해 ID 앞에 임의로 0을 붙여도(0001 등) 인식됩니다.
후자는 디렉터리 이름이 조금 지저분해 보일 수 있으나 주소창에서 복사해 바로 쓸 수 있도록(Windows 기준으로 /는 알아서 제거됨) 추가했습니다.

예를 들어 [https://ci-en.net/creator/1/article/58152](https://ci-en.net/creator/1/article/58152)의 정보를 가져온다면
`CE1-58152`, `Cien0000001-0058152`, `CEcreator1article58152`, `Ci-en0000001article0058152` 모두 가능합니다.

Ci-en 특성 상 카테고리와 태그 정보는 가져오지 않으며 섬네일은 기사 본문의 가장 첫 번째 이미지를 가져오게 됩니다.

약 10개의 투고 기사로 확인한 결과 발견된 문제는 없었으나 한 번 더 확인 부탁드립니다.